### PR TITLE
Start making this a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gemspec

--- a/yast2-docker.gemspec
+++ b/yast2-docker.gemspec
@@ -1,0 +1,25 @@
+Gem::Specification.new do |spec|
+
+  # gem name and description
+  spec.name     = "yast2-docker"
+  spec.version  = "3.1.0"
+  spec.summary  = "YaST2 - GUI for docker management"
+  spec.license  = "GPL-2.0 or GPL-3.0"
+  spec.authors  = ["Flavio Castelli", "Josef Reidinger"]
+  spec.homepage = "http://github.org/yast/yast-docker"
+
+  # gem content
+  spec.files   = Dir[
+    "doc/*.png", "src/**/*.rb", "src/desktop/*.desktop",
+    "test/*.rb", "README.md"
+  ]
+
+  # define LOAD_PATH
+  spec.require_path = "src/lib"
+
+  # dependencies
+  spec.add_dependency "docker-api"
+
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "yast-rake"
+end


### PR DESCRIPTION
Since this module requires docker-api.gem and it is a brand new yast module, it is a natural candidate to experimewnt with packaging yast modules as gems.

It does BUILD a gem, which certainly does not WORK, but it was useful for me to install the dependencies with bundler. Well, I cannot RUN the thing with bundler either (because `/sbin/yast2` purges the environment)...