### PR TITLE
fixed string substitution

### DIFF
--- a/src/lib/ydocker/inject_shell_dialog.rb
+++ b/src/lib/ydocker/inject_shell_dialog.rb
@@ -114,7 +114,7 @@ module YDocker
       else
         res = `xterm -e 'nsenter --target #{pid} --mount --uts --ipc --net --pid #{Shellwords.escape selected_shell} || (echo "Failed to attach. Will close window in 5 seconds";sleep 5)' 2>&1`
         if $?.exitstatus != 0
-          Yast::Popup.Error(_("Failed to run terminal. Error: #{res}"))
+          Yast::Popup.Error(_("Failed to run terminal. Error: %{error}") % { :error => res })
           return
         end
       end


### PR DESCRIPTION
Note: `#{foo}` does not work properly in translated messages (the substitution is done _before_ translating the string).

BTW it looks like some permissions are missing, I could not push a new branch, I had to clone the repo...
