### PR TITLE
Handle correctly cancel buttons in "run image" dialog

### DIFF
--- a/package/yast2-docker.changes
+++ b/package/yast2-docker.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  6 13:46:39 UTC 2015 - ancor@suse.com
+
+- Release 3.1.3
+  - Fixed an error handling the cancel button at the ports and
+    volumes pop-up windows (bnc#920638)
+
+-------------------------------------------------------------------
 Tue Feb 24 15:05:53 UTC 2015 - ancor@suse.com
 
 - Release 3.1.2

--- a/package/yast2-docker.spec
+++ b/package/yast2-docker.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-docker
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/ydocker/run_image_dialog.rb
+++ b/src/lib/ydocker/run_image_dialog.rb
@@ -174,13 +174,15 @@ module YDocker
         )
       )
 
-      return if Yast::UI.UserInput == :cancel
+      if Yast::UI.UserInput == :cancel
+        Yast::UI.CloseDialog
+      else
+        @volumes << { :source => dir, :target => Yast::UI.QueryWidget(:target, :Value) }
 
-      @volumes << { :source => dir, :target => Yast::UI.QueryWidget(:target, :Value) }
+        Yast::UI.CloseDialog
 
-      Yast::UI.CloseDialog
-
-      redraw_volumes
+        redraw_volumes
+      end
     end
 
     def remove_volume
@@ -200,16 +202,18 @@ module YDocker
         )
       )
 
-      return if Yast::UI.UserInput == :cancel
+      if Yast::UI.UserInput == :cancel
+        Yast::UI.CloseDialog
+      else
+        @ports << {
+          :external => Yast::UI.QueryWidget(:external, :Value),
+          :internal => Yast::UI.QueryWidget(:internal, :Value)
+        }
 
-      @ports << {
-        :external => Yast::UI.QueryWidget(:external, :Value),
-        :internal => Yast::UI.QueryWidget(:internal, :Value)
-      }
+        Yast::UI.CloseDialog
 
-      Yast::UI.CloseDialog
-
-      redraw_ports
+        redraw_ports
+      end
     end
 
     def remove_port


### PR DESCRIPTION
The methods returned without actually closing the pop-up windows, which leaded to inconsistent state and crazy crashes.