### PR TITLE
fix for bsc#938441 - prompt before removing container on stop and kill

### DIFF
--- a/src/lib/ydocker/main_dialog.rb
+++ b/src/lib/ydocker/main_dialog.rb
@@ -151,6 +151,7 @@ module YDocker
     def stop_container
       return unless (Yast::Popup.YesNo(_("Do you really want to stop the running container?")))
       selected_container.stop!
+      return unless (Yast::Popup.YesNo(_("Do you want to remove the container?")))
       selected_container.delete
 
       redraw_containers
@@ -159,6 +160,7 @@ module YDocker
     def kill_container
       return unless (Yast::Popup.YesNo(_("Do you really want to kill the running container?")))
       selected_container.kill!
+      return unless (Yast::Popup.YesNo(_("Do you want to remove the container?")))
       selected_container.delete
 
       redraw_containers


### PR DESCRIPTION
This is the fix I submitted for bsc#938441.

It simply adds a yes/no dialog regarding removing the container for
stop and kill operations.