### PR TITLE
Fix Internal Error with docker 25.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@
 inherit_from:
   - /usr/share/YaST2/data/devtools/data/rubocop-1.24.1_yast_style.yml
   - .rubocop_todo.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 # use the shared Yast defaults
 inherit_from:
-  - /usr/share/YaST2/data/devtools/data/rubocop_yast_style.yml
+  - /usr/share/YaST2/data/devtools/data/rubocop-1.24.1_yast_style.yml
   - .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,6 +15,9 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 14
 
+Metrics/BlockLength:
+  Max: 35
+
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/package/yast2-docker.changes
+++ b/package/yast2-docker.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 11 09:10:02 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Fix Internal Error with docker 25.0.0 due to VirtualSize removal
+  from images API (bsc#1222668, gh#yast/yast-docker#32)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-docker.spec
+++ b/package/yast2-docker.spec
@@ -24,7 +24,7 @@
 ######################################################################
 
 Name:           yast2-docker
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - GUI for docker management
 Group:          System/YaST

--- a/src/lib/ydocker/changes_dialog.rb
+++ b/src/lib/ydocker/changes_dialog.rb
@@ -48,14 +48,13 @@ module YDocker
     end
 
     def controller_loop
-      loop do
-        input = Yast::UI.UserInput
-        case input
-        when :ok, :cancel
-          return :ok
-        else
-          raise "Unknown action #{input}"
-        end
+      # no need to loop, one shot is enough
+      input = Yast::UI.UserInput
+      case input
+      when :ok, :cancel
+        :ok
+      else
+        raise "Unknown action #{input}"
       end
     end
 

--- a/src/lib/ydocker/changes_dialog.rb
+++ b/src/lib/ydocker/changes_dialog.rb
@@ -33,7 +33,7 @@ module YDocker
       return unless create_dialog
 
       begin
-        return controller_loop
+        controller_loop
       ensure
         close_dialog
       end

--- a/src/lib/ydocker/commit_dialog.rb
+++ b/src/lib/ydocker/commit_dialog.rb
@@ -33,7 +33,7 @@ module YDocker
       return unless create_dialog
 
       begin
-        return controller_loop
+        controller_loop
       ensure
         close_dialog
       end

--- a/src/lib/ydocker/inject_shell_dialog.rb
+++ b/src/lib/ydocker/inject_shell_dialog.rb
@@ -50,17 +50,15 @@ module YDocker
     end
 
     def controller_loop
-      loop do
-        input = Yast::UI.UserInput
-        case input
-        when :ok
-          attach
-          return
-        when :cancel
-          return
-        else
-          raise "Unknown action #{input}"
-        end
+      # no need to loop, one shot is enough
+      input = Yast::UI.UserInput
+      case input
+      when :ok
+        attach
+      when :cancel
+        nil
+      else
+        raise "Unknown action #{input}"
       end
     end
 

--- a/src/lib/ydocker/inject_shell_dialog.rb
+++ b/src/lib/ydocker/inject_shell_dialog.rb
@@ -35,7 +35,7 @@ module YDocker
       return unless create_dialog
 
       begin
-        return controller_loop
+        controller_loop
       ensure
         close_dialog
       end
@@ -116,9 +116,9 @@ module YDocker
             " || (echo \"Failed to attach. Will close window in 5 seconds\";sleep 5)"
 
           Yast::Execute.locally!("xterm", "-e", command)
-        rescue Cheetah::ExecutionFailed => error
+        rescue Cheetah::ExecutionFailed => e
           Yast::Popup.Error(
-            format(_("Failed to run terminal. Error: %{error}"), error: error.message)
+            format(_("Failed to run terminal. Error: %{error}"), error: e.message)
           )
         end
       end

--- a/src/lib/ydocker/main_dialog.rb
+++ b/src/lib/ydocker/main_dialog.rb
@@ -48,7 +48,7 @@ module YDocker
       return unless create_dialog
 
       begin
-        return controller_loop
+        controller_loop
       ensure
         close_dialog
       end
@@ -75,11 +75,11 @@ module YDocker
           _("Docker service does not run. Should YaST start docker? Otherwise YaST quits.")
         )
 
-        return Yast::Service.start("docker")
+        Yast::Service.start("docker")
       else
         Yast::Popup.Error(_("Docker service does not run. \
 Run this module as root or start docker service manually."))
-        return false
+        false
       end
     end
 
@@ -155,8 +155,10 @@ Run this module as root or start docker service manually."))
 
     def stop_container
       return unless Yast::Popup.YesNo(_("Do you really want to stop the running container?"))
+
       selected_container.stop!
       return unless Yast::Popup.YesNo(_("Do you want to remove the container?"))
+
       selected_container.delete
 
       redraw_containers
@@ -164,8 +166,10 @@ Run this module as root or start docker service manually."))
 
     def kill_container
       return unless Yast::Popup.YesNo(_("Do you really want to kill the running container?"))
+
       selected_container.kill!
       return unless Yast::Popup.YesNo(_("Do you want to remove the container?"))
+
       selected_container.delete
 
       redraw_containers

--- a/src/lib/ydocker/main_dialog.rb
+++ b/src/lib/ydocker/main_dialog.rb
@@ -275,7 +275,7 @@ Run this module as root or start docker service manually."))
             tag,
             image.id.slice(0, 12),
             DateTime.strptime(image.info["Created"].to_s, "%s").to_s,
-            Y2Storage::DiskSize.new(image.info["VirtualSize"]).to_human_string
+            Y2Storage::DiskSize.new(image.info["Size"]).to_human_string
           )
         end
       end

--- a/src/lib/ydocker/run_image_dialog.rb
+++ b/src/lib/ydocker/run_image_dialog.rb
@@ -37,7 +37,7 @@ module YDocker
       return unless create_dialog
 
       begin
-        return controller_loop
+        controller_loop
       ensure
         close_dialog
       end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2017 SUSE LLC
 #
@@ -19,7 +17,7 @@
 # current contact information at www.suse.com.
 # ------------------------------------------------------------------------------
 
-$LOAD_PATH.unshift(File.expand_path("../../src/lib", __FILE__))
+$LOAD_PATH.unshift(File.expand_path("../src/lib", __dir__))
 
 RSpec.configure do |config|
   config.mock_with :rspec do |c|
@@ -36,7 +34,7 @@ if ENV["COVERAGE"]
   end
 
   # track all ruby files under src
-  src_location = File.expand_path("../../src", __FILE__)
+  src_location = File.expand_path("../src", __dir__)
   SimpleCov.track_files("#{src_location}/**/*.rb")
 
   # additionally use the LCOV format for on-line code coverage reporting at CI


### PR DESCRIPTION
## Problem

- https://github.com/yast/yast-docker/issues/32
- (copied to Bugzilla as https://bugzilla.suse.com/show_bug.cgi?id=1222668 for OBS submission)

Since Docker 25.0.0, starting `yast2 docker` just pops up an Internal Error (unless you have no images at all)

https://docs.docker.com/engine/api/v1.45/#tag/Image/operation/ImageList says for VirtualSize
> Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.


## Solution

So we need to fix yast2-docker to use `image.info["Size"]` instead


## Testing

Tested manually that the fix works with **older** Docker (on Leap 15.4 with 24.0.7)
